### PR TITLE
so pip actually installs the templates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     packages=['colorfield'],
+    include_package_data=True,
     install_requires=['django>=1.2'],
     requires=['django (>=1.2)'],
 )


### PR DESCRIPTION
fixes TemplateDoesNotExist at ...colorfield/color.html error wen installing via

pip install django-colorfield
