### PR TITLE
fix: accomodate non-required fields

### DIFF
--- a/colorfield/fields.py
+++ b/colorfield/fields.py
@@ -4,7 +4,6 @@ import re
 
 from django import forms
 from django.db import models
-from django.conf import settings
 from django.core.validators import RegexValidator
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
@@ -17,7 +16,7 @@ class ColorWidget(forms.Widget):
     class Media:
         js = ['colorfield/jscolor/jscolor.min.js']
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         return render_to_string('colorfield/color.html', {
             'name': name,
             'value': value,

--- a/colorfield/fields.py
+++ b/colorfield/fields.py
@@ -18,7 +18,12 @@ class ColorWidget(forms.Widget):
         js = ['colorfield/jscolor/jscolor.min.js']
 
     def render(self, name, value, attrs=None):
-        return render_to_string('colorfield/color.html', locals())
+        return render_to_string('colorfield/color.html', {
+            'name': name,
+            'value': value,
+            'attrs': attrs,
+            'is_required': self.is_required
+        })
 
 
 class ColorField(models.CharField):

--- a/colorfield/templates/colorfield/color.html
+++ b/colorfield/templates/colorfield/color.html
@@ -1,2 +1,7 @@
-<input type="text" name="{{ name }}" value="{{ value }}" id="{{ attrs.id }}"
-class="colorfield_field jscolor {hash:true}"/>
+<input
+  type="text"
+  name="{{ name }}"
+  value="{{ value|default_if_none:'' }}"
+  id="{{ attrs.id }}"
+  class="colorfield_field jscolor {hash:true, required:{{ is_required|lower }}}"
+/>

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,0 +1,39 @@
+import unittest
+
+try:
+    from unittest import mock  # Python 3
+except ImportError:
+    import mock  # Python 2
+
+from colorfield.fields import ColorWidget
+
+
+class ColorWidgetTestCase(unittest.TestCase):
+
+    @mock.patch("colorfield.fields.render_to_string")
+    def test_render_with_is_required_true(self, m):
+
+        widget = mock.Mock(spec=ColorWidget)
+        widget.is_required = True
+
+        ColorWidget.render(widget, "alpha", "bravo", {"charlie": "delta"})
+
+        self.assertEqual(m.call_count, 1)
+        self.assertEqual(len(m.call_args[0]), 2)
+        self.assertEqual(m.call_args[0][0], "colorfield/color.html")
+        self.assertEqual(len(m.call_args[0][1]), 4)
+
+        self.assertEqual(m.call_args[0][1]["name"], "alpha")
+        self.assertEqual(m.call_args[0][1]["value"], "bravo")
+        self.assertEqual(m.call_args[0][1]["attrs"], {"charlie": "delta"})
+        self.assertEqual(m.call_args[0][1]["is_required"], True)
+
+    @mock.patch("colorfield.fields.render_to_string")
+    def test_render_with_is_required_false(self, m):
+
+        widget = mock.Mock(spec=ColorWidget)
+        widget.is_required = False
+
+        ColorWidget.render(widget, "alpha", "bravo", {"charlie": "delta"})
+
+        self.assertEqual(m.call_args[0][1]["is_required"], False)


### PR DESCRIPTION
In cases where `requried=False`, the current code forces `#FFFFFF` which isn't ideal.  This commit does two things to fix this:

1. Instead of passing `locals()` (which includes an unused `self`), we explicitly pass the values we want, including `is_required`.
2. Patches the template to include `required;????` as per the jscolor library's options.

As an aside, jscolor also allows you to exclude the `#` from the form field if you like, which would be handy since there's no reason to store it in the database.  If you'd like I can issue a separate PR to do that.