### PR TITLE
FIX: Removes function eval for CSP compatibility

### DIFF
--- a/colorfield/static/colorfield/jscolor/jscolor.js
+++ b/colorfield/static/colorfield/jscolor/jscolor.js
@@ -59,7 +59,7 @@ var jsc = {
 				var opts = {};
 				if (optsStr) {
 					try {
-						opts = (new Function ('return (' + optsStr + ')'))();
+						opts = JSON.parse(optsStr);
 					} catch(eParseError) {
 						jsc.warn('Error parsing jscolor options: ' + eParseError + ':\n' + optsStr);
 					}

--- a/colorfield/templates/colorfield/color.html
+++ b/colorfield/templates/colorfield/color.html
@@ -1,2 +1,2 @@
 <input type="text" name="{{ name }}" {% if value %}value="{{ value }}"{% endif %} id="{{ attrs.id }}"
-class="colorfield_field jscolor {% if not is_required %}{required:false}{% endif %}"/>
+class="colorfield_field jscolor" {% if not is_required %}data-jscolor="{&quot;required&quot;: false}"{% endif %}/>


### PR DESCRIPTION
In order to enforce an effective CSP, sites must disallow the use of `eval` in scripts, as they are a common exploit vector for attacks. Unfortunately, django-colorfield uses one (in the form of a string-based function) to pass information to the front-end when rendering the widget. This causes it to break when such a CSP is enforced.

This PR fixes the issue by replacing the string-based function with `JSON.parse`. To do so required that the template be modified slightly for it to output valid JSON. Additionally, I moved the option declaration from the class attribute to its own data attribute, which I noticed was already supported.