### PR TITLE
JSColor Not Loading Correctly When Fields Loaded Dynamically | Changing Default to None

### DIFF
--- a/colorfield/fields.py
+++ b/colorfield/fields.py
@@ -23,7 +23,7 @@ class ColorField(models.CharField):
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('max_length', 18)
-        kwargs.setdefault('default', '#FFFFFF')
+        kwargs.setdefault('default', None)
         super(ColorField, self).__init__(*args, **kwargs)
 
     def formfield(self, **kwargs):

--- a/colorfield/static/colorfield/colorfield.js
+++ b/colorfield/static/colorfield/colorfield.js
@@ -2,12 +2,10 @@
 
 window.onload = function() {
     if (typeof(django) !== 'undefined' && typeof(django.jQuery) !== 'undefined') {
-        (function($) {
+        (function($) { 
             // add colopicker to inlines added dynamically
             $(document).on('formset:added', function onFormsetAdded(event, row) {
-                $(row['0']).find('.colorfield_field.jscolor').not('.jscolor-active').each(function(index, el) {
-                    var picker = new jscolor($(el).get(0));
-                });
+                jscolor.installByClassName("jscolor");
             });
         }(django.jQuery));
     }


### PR DESCRIPTION
Using jscolor.installByClassName() to instantiate jscolor fileds to correct issues when the color fields are loaded dynamically.

Setting the default color value to None if no default is set on the model.  Hardcoding a default value makes this less flexible as there is no way to force the user to take action on the field.