### PR TITLE
Use "load" event instead of window.onload

### DIFF
--- a/colorfield/static/colorfield/colorfield.js
+++ b/colorfield/static/colorfield/colorfield.js
@@ -1,6 +1,6 @@
 /** global: django */
 
-window.onload = function() {
+window.addEventListener('load', (event) => {
     if (typeof(django) !== 'undefined' && typeof(django.jQuery) !== 'undefined') {
         (function($) {
             // add colopicker to inlines added dynamically
@@ -9,4 +9,4 @@ window.onload = function() {
             });
         })(django.jQuery);
     }
-};
+});


### PR DESCRIPTION
Other js files may attempt to listen for the window.onload event, the last function assigned would be the one set.
We can use addEventListener to listen for the ``load`` event instead which is the same.

https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event