### PR TITLE
Check for length of choices before performing lookup

### DIFF
--- a/colorfield/fields.py
+++ b/colorfield/fields.py
@@ -53,7 +53,8 @@ class ColorField(models.CharField):
 
     def formfield(self, **kwargs):
         palette = []
-        if self.choices is not None:
+        if (self.choices is not None
+                and len(self.choices) > 0):
             choices = self.get_choices(include_blank=False)
             palette = [choice[0] for choice in choices]
         kwargs['widget'] = ColorWidget(attrs={

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,8 +1,18 @@
 # -*- coding: utf-8 -*-
 
+from django import forms
+from django.forms import fields_for_model
+from django.db import models
 from django.test import TestCase
 
 from colorfield.fields import ColorField
+
+
+class ColoredModel(models.Model):
+    colors = ColorField(blank=True)
+
+    class Meta:
+        app_label = 'colorfield'
 
 
 class ColorFieldTestCase(TestCase):
@@ -12,3 +22,11 @@ class ColorFieldTestCase(TestCase):
 
     def tearDown(self):
         pass
+
+    def test_model_formfield_doesnt_raise(self):
+        """Adding a ColoredField to a model should not fail in 2.2LTS
+        """
+        try:
+            fields_for_model(ColoredModel())
+        except AttributeError:
+            self.fail('Raised Attribute Error')


### PR DESCRIPTION
Relates to https://github.com/fabiocaccamo/django-colorfield/pull/64. 

In Django 2.2, choices is [] by default. Perform a lookup that choices have been passed before doing the palette lookup.
Otherwise an AttributeError is raised as follows: 
```
AttributeError: 'NoneType' object has no attribute 'model'
```

Also added test case confirming the behavior.

