### PR TITLE
Add non-restrictive palette choices option

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,15 +1,19 @@
 # -*- coding: utf-8 -*-
 
-from django import forms
-from django.forms import fields_for_model
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
+from django.forms import fields_for_model
 from django.test import TestCase
 
 from colorfield.fields import ColorField
 
-
 class ColoredModel(models.Model):
-    colors = ColorField(blank=True)
+    COLOR_CHOICES = [
+        ("#FFFFFF", "white"),
+        ("#000000", "black")
+    ]
+
+    colors = ColorField(blank=True, samples=COLOR_CHOICES)
 
     class Meta:
         app_label = 'colorfield'
@@ -18,7 +22,7 @@ class ColoredModel(models.Model):
 class ColorFieldTestCase(TestCase):
 
     def setUp(self):
-        pass
+        self.instance = ColoredModel()
 
     def tearDown(self):
         pass
@@ -30,3 +34,29 @@ class ColorFieldTestCase(TestCase):
             fields_for_model(ColoredModel())
         except AttributeError:
             self.fail('Raised Attribute Error')
+    
+    def test_model_formfield_with_samples_and_choices_fails(self):
+        """
+        Checks that supplying a ColorField with both samples and choices options fails (mutually exclusive)
+        """
+        with self.assertRaises(ImproperlyConfigured):
+            ColorField(choices=ColoredModel.COLOR_CHOICES, samples=ColoredModel.COLOR_CHOICES)
+
+    def test_clean_field_samples(self):
+        """
+        Checks that supplying a ColorField with the samples kwarg works, and that it accepts valid values outside the predefined choices
+        """
+        # 1. Test with predefined choice
+        self.instance.colors = self.instance.COLOR_CHOICES[0][0]
+        try:
+            self.instance.full_clean()
+        except ValidationError as e:
+            self.fail('Failed to assign predefined palette choice to ColorField model instance. Message: {}'.format(e))
+        
+        # 2. Test with value outside of the choices
+        other_value = '#35B6A3'
+        self.instance.colors = other_value
+        try:
+            self.instance.full_clean()
+        except ValidationError as e:
+            self.fail('Failed to assign value outside palette choices to ColorField model instance. Message: {}'.format(e))


### PR DESCRIPTION
addresses Issue #68 
This PR proposes a new field option which works similarly to django's `choices` kwarg, the difference being that the field's values are not restricted to the given choices. This way, one can use both the color palette and the color picker. Until now, with `choices` defined, the color picker is effectively useless, since we cannot choose values outside of the palette.

The supplied screenshot shows this logic in action in a sample django project. It illustrates the ability to save a color value outside the predefined choices. I realise screenshots are not necessarily always accurate - there is always a possibility that I doctored/edited it - so I have also added a test that cleans a model instance with `palette_choices` set and a supplied value outside those choices. Feel free to run the code yourself as well and test it all out.

I have replaced the `choices` option with the new option here. Please let me know if we should keep the original `choices` as well. Perhaps adding some logic to make the two options mutually exclusive would be a good idea.

![image](https://user-images.githubusercontent.com/22740950/144725310-64eba746-621a-4b27-b9d2-cc16237ecc12.png)

