### PR TITLE
Fix warnings in browser console when using ColorWidget without specif…

### DIFF
--- a/colorfield/widgets.py
+++ b/colorfield/widgets.py
@@ -29,6 +29,8 @@ class ColorWidget(TextInput):
                 "value": value,
             }
         )
+        if "format" not in context:
+            context.update({"format": "hex"})
         return context
 
     def render(self, name, value, attrs=None, renderer=None):


### PR DESCRIPTION
…ying format

Avoids the following warning:

```
Error: Option 'format' has invalid value:
    setOption http://0.0.0.0:8000/static/colorfield/jscolor/jscolor.js:2360
    pub http://0.0.0.0:8000/static/colorfield/jscolor/jscolor.js:3089
    installBySelector http://0.0.0.0:8000/static/colorfield/jscolor/jscolor.js:111
    install http://0.0.0.0:8000/static/colorfield/jscolor/jscolor.js:3381
    init http://0.0.0.0:8000/static/colorfield/jscolor/jscolor.js:3364
    register http://0.0.0.0:8000/static/colorfield/jscolor/jscolor.js:56
    jscolor http://0.0.0.0:8000/static/colorfield/jscolor/jscolor.js:3506
    <anonymous> http://0.0.0.0:8000/static/colorfield/jscolor/jscolor.js:3512
    <anonymous> http://0.0.0.0:8000/static/colorfield/jscolor/jscolor.js:32
    <anonymous> http://0.0.0.0:8000/static/colorfield/jscolor/jscolor.js:34
```

---
name: Pull request
about: Submit a pull request for this project
assignees: fabiocaccamo

---

**Describe your changes**
?

**Related issue**
?

**Checklist before requesting a review**
- [ ] I have performed a self-review of my code.
- [ ] I have added tests for the proposed changes.
- [ ] I have run the tests and there are not errors.
