### PR TITLE
Add support for RGB and RGBA formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ These are the supported custom options: [`format`](#format), [`image_field`](#im
 
 #### format
 
-The following formats are supported: `hex` *(default)*, `hexa`.
+The following formats are supported: `hex` *(default)*, `hexa`, `rgb`, `rgba`.
 
 ```python
 from colorfield.fields import ColorField

--- a/colorfield/fields.py
+++ b/colorfield/fields.py
@@ -3,12 +3,27 @@ from django.db.models import CharField, signals
 from django.db.models.fields.files import ImageField
 
 from colorfield.utils import get_image_file_background_color
-from colorfield.validators import color_hex_validator, color_hexa_validator
+from colorfield.validators import (
+    color_hex_validator,
+    color_hexa_validator,
+    color_rgb_validator,
+    color_rgba_validator,
+)
 from colorfield.widgets import ColorWidget
 
-VALIDATORS_PER_FORMAT = {"hex": color_hex_validator, "hexa": color_hexa_validator}
+VALIDATORS_PER_FORMAT = {
+    "hex": color_hex_validator,
+    "hexa": color_hexa_validator,
+    "rgb": color_rgb_validator,
+    "rgba": color_rgba_validator,
+}
 
-DEFAULT_PER_FORMAT = {"hex": "#FFFFFF", "hexa": "#FFFFFFFF"}
+DEFAULT_PER_FORMAT = {
+    "hex": "#FFFFFF",
+    "hexa": "#FFFFFFFF",
+    "rgb": "rgb(255, 255, 255)",
+    "rgba": "rgba(255, 255, 255, 1)",
+}
 
 
 class ColorField(CharField):
@@ -18,7 +33,7 @@ class ColorField(CharField):
         # works like Django choices, but does not restrict input to the given choices
         self.samples = kwargs.pop("samples", None)
         self.format = kwargs.pop("format", "hex").lower()
-        if self.format not in ["hex", "hexa"]:
+        if self.format not in ["hex", "hexa", "rgb", "rgba"]:
             raise ValueError(f"Unsupported color format: {self.format}")
         self.default_validators = [VALIDATORS_PER_FORMAT[self.format]]
 
@@ -78,7 +93,7 @@ class ColorField(CharField):
         color = ""
         image_file = getattr(instance, self.image_field)
         if image_file:
-            alpha = self.format == "hexa"
+            alpha = self.format in {"hexa", "rgba"}
             with image_file.open() as _:
                 color = get_image_file_background_color(image_file, alpha)
         return color

--- a/colorfield/serializers.py
+++ b/colorfield/serializers.py
@@ -6,7 +6,12 @@ try:
 except ImportError:
     ModuleNotFoundError("Django REST Framework is not installed.")
 
-from colorfield.validators import color_hex_validator, color_hexa_validator
+from colorfield.validators import (
+    color_hex_validator,
+    color_hexa_validator,
+    color_rgb_validator,
+    color_rgba_validator,
+)
 
 
 class ColorField(CharField):
@@ -14,23 +19,39 @@ class ColorField(CharField):
         "invalid": [
             color_hex_validator.message,
             color_hexa_validator.message,
+            color_rgb_validator.message,
+            color_rgba_validator.message,
         ]
     }
 
     def to_internal_value(self, data):
-        has_hex_error = False
-        has_hexa_error = False
+        errors = {
+            "hex": False,
+            "hexa": False,
+            "rgb": False,
+            "rgba": False,
+        }
         try:
             color_hex_validator(data)
         except DjangoValidationError:
-            has_hex_error = True
+            errors["hex"] = True
 
         try:
             color_hexa_validator(data)
         except DjangoValidationError:
-            has_hexa_error = True
+            errors["hexa"] = True
 
-        if has_hex_error and has_hexa_error:
+        try:
+            color_rgb_validator(data)
+        except DjangoValidationError:
+            errors["rgb"] = True
+
+        try:
+            color_rgba_validator(data)
+        except DjangoValidationError:
+            errors["rgba"] = True
+
+        if all(errors.values()):
             raise DRFValidationError(self.default_error_messages.get("invalid"))
 
         return data

--- a/colorfield/validators.py
+++ b/colorfield/validators.py
@@ -17,3 +17,50 @@ color_hexa_validator = RegexValidator(
     _("Enter a valid hexa color, eg. #00000000"),
     "invalid",
 )
+
+COLOR_RGB_RE = re.compile(
+    # prefix and opening parenthesis
+    r"^rgb\("
+    # first number
+    r"(\d{1,3})"
+    # comma and optional space
+    r",\s?"
+    # second number
+    r"(\d{1,3})"
+    # comma and optional space
+    r",\s?"
+    # third number
+    r"(\d{1,3})"
+    # closing parenthesis
+    r"\)$"
+)
+color_rgb_validator = RegexValidator(
+    COLOR_RGB_RE,
+    _("Enter a valid rgb color, eg. rgb(128, 128, 128)"),
+    "invalid",
+)
+COLOR_RGBA_RE = re.compile(
+    # prefix and opening parenthesis
+    r"^rgba\("
+    # first number
+    r"(\d{1,3})"
+    # comma and optional space
+    r",\s?"
+    # second number
+    r"(\d{1,3})"
+    # comma and optional space
+    r",\s?"
+    # third number§
+    r"(\d{1,3})"
+    # comma and optional space
+    r",\s?"
+    # alpha channel: decimal number between 0 and 1
+    r"([0-1](\.\d+)?)"
+    # closing parenthesis
+    r"\)$"
+)
+color_rgba_validator = RegexValidator(
+    COLOR_RGBA_RE,
+    _("Enter a valid rgba color, eg. rgba(128, 128, 128, 0.5)"),
+    "invalid",
+)

--- a/colorfield/validators.py
+++ b/colorfield/validators.py
@@ -55,7 +55,7 @@ COLOR_RGBA_RE = re.compile(
     # comma and optional space
     r",\s?"
     # alpha channel: decimal number between 0 and 1
-    r"(0(\.\d{1,2})?|1)"
+    r"(0(\.\d{1,2})?|1(\.0)?)"
     # closing parenthesis
     r"\)$"
 )

--- a/colorfield/validators.py
+++ b/colorfield/validators.py
@@ -21,15 +21,15 @@ color_hexa_validator = RegexValidator(
 COLOR_RGB_RE = re.compile(
     # prefix and opening parenthesis
     r"^rgb\("
-    # first number
+    # first number: red channel
     r"(\d{1,3})"
     # comma and optional space
     r",\s?"
-    # second number
+    # second number: green channel
     r"(\d{1,3})"
     # comma and optional space
     r",\s?"
-    # third number
+    # third number: blue channel
     r"(\d{1,3})"
     # closing parenthesis
     r"\)$"
@@ -42,15 +42,15 @@ color_rgb_validator = RegexValidator(
 COLOR_RGBA_RE = re.compile(
     # prefix and opening parenthesis
     r"^rgba\("
-    # first number
+    # first number: red channel
     r"(\d{1,3})"
     # comma and optional space
     r",\s?"
-    # second number
+    # second number: green channel
     r"(\d{1,3})"
     # comma and optional space
     r",\s?"
-    # third number§
+    # third number: blue channel
     r"(\d{1,3})"
     # comma and optional space
     r",\s?"

--- a/colorfield/validators.py
+++ b/colorfield/validators.py
@@ -55,7 +55,7 @@ COLOR_RGBA_RE = re.compile(
     # comma and optional space
     r",\s?"
     # alpha channel: decimal number between 0 and 1
-    r"([0-1](\.\d+)?)"
+    r"(0(\.\d+)?|1)"
     # closing parenthesis
     r"\)$"
 )

--- a/colorfield/validators.py
+++ b/colorfield/validators.py
@@ -55,7 +55,7 @@ COLOR_RGBA_RE = re.compile(
     # comma and optional space
     r",\s?"
     # alpha channel: decimal number between 0 and 1
-    r"(0(\.\d+)?|1)"
+    r"(0(\.\d{1,2})?|1)"
     # closing parenthesis
     r"\)$"
 )

--- a/tests/models.py
+++ b/tests/models.py
@@ -77,3 +77,11 @@ class ColorImageFieldAndFormat(models.Model):
 
     class Meta:
         app_label = "tests"
+
+
+class ColorFieldRGBFormat(models.Model):
+    color_rgb = ColorField(format="rgb")
+    color_rgba = ColorField(format="rgba")
+
+    class Meta:
+        app_label = "tests"

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -12,6 +12,7 @@ from tests.models import (
     COLOR_PALETTE,
     Color,
     ColorChoices,
+    ColorFieldRGBFormat,
     ColorImageField,
     ColorImageFieldAndDefault,
     ColorImageFieldAndFormat,
@@ -166,3 +167,17 @@ class ColorFieldTestCase(TestCase):
         # check stored value
         obj_saved = model_class.objects.get(pk=obj.pk)
         self.assertEqual(obj_saved.color, expected_color)
+
+    def test_model_rgb_formats(self):
+        obj = ColorFieldRGBFormat(
+            color_rgb="rgb(123, 123, 123)",
+            color_rgba="rgba(5, 10, 128, 0.5)",
+        )
+        obj.save()
+        # check in-memory values
+        self.assertEqual(obj.color_rgb, "rgb(123, 123, 123)")
+        self.assertEqual(obj.color_rgba, "rgba(5, 10, 128, 0.5)")
+        # check stored value
+        obj_saved = ColorFieldRGBFormat.objects.get(pk=obj.pk)
+        self.assertEqual(obj_saved.color_rgb, "rgb(123, 123, 123)")
+        self.assertEqual(obj_saved.color_rgba, "rgba(5, 10, 128, 0.5)")

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -5,7 +5,7 @@ from rest_framework.serializers import ValidationError as DRFValidationError
 from colorfield.serializers import ColorField
 
 
-class SerializerWithHexColor(Serializer):
+class SerializerWithColor(Serializer):
     color = ColorField()
 
 
@@ -27,68 +27,134 @@ class ColorFieldTestCase(TestCase):
         self.invalid_hexa_short_color1 = "#12345"
         self.invalid_hexa_short_color2 = "#123R"
 
+        self.valid_rgb_colors = [
+            "rgb(5, 3, 6)",
+            "rgb(5,3,6)",
+            "rgb(50, 30, 128)",
+            "rgb(45,10, 99)",
+            "rgb(128, 128, 128)",
+            "rgb(156,200,250)",
+        ]
+        self.invalid_rgb_colors = [
+            "rgb(5)",
+            "rgb(5, 6)",
+            "rgb(128,255)",
+            "rgb(128,A)",
+            "rgb(128, 128, A)",
+            "rgb(128,255,12,30)",
+            "rgb(128, 255, 12, A)",
+        ]
+
+        self.valid_rgba_colors = [
+            "rgba(5, 3, 6, 1)",
+            "rgba(5,3,6,1)",
+            "rgba(50, 30, 128, 0.5)",
+            "rgba(45,10, 99, 0.6)",
+            "rgba(128, 128, 128, 0.3)",
+            "rgba(156,200,250,0)",
+        ]
+        self.invalid_rgba_colors = [
+            "rgba(10)",
+            "rgba(50, 100)",
+            "rgba(120,199)",
+            "rgba(1, 2, 3)",
+            "rgba(128,255,127)",
+            "rgba(128,255,127,A)",
+            "rgba(128, 255, 127, A)",
+            "rgba(128, 12, 35, 1, 1)",
+            "rgba(128, 12, 35, 1, 1, 2)",
+        ]
+
     def test_valid_serializer(self):
         data = {"color": self.valid_hex_full_color}
-        serializer = SerializerWithHexColor(data=data)
+        serializer = SerializerWithColor(data=data)
         self.assertTrue(serializer.is_valid())
 
         data = {"color": self.valid_hex_short_color}
-        serializer = SerializerWithHexColor(data=data)
+        serializer = SerializerWithColor(data=data)
         self.assertTrue(serializer.is_valid())
 
         data = {"color": self.valid_hexa_full_color}
-        serializer = SerializerWithHexColor(data=data)
+        serializer = SerializerWithColor(data=data)
         self.assertTrue(serializer.is_valid())
 
         data = {"color": self.valid_hexa_short_color}
-        serializer = SerializerWithHexColor(data=data)
+        serializer = SerializerWithColor(data=data)
         self.assertTrue(serializer.is_valid())
+
+        for value in self.valid_rgb_colors:
+            with self.subTest(f"RGB={value}"):
+                data = {"color": value}
+                serializer = SerializerWithColor(data=data)
+                self.assertTrue(serializer.is_valid())
+
+        for value in self.valid_rgba_colors:
+            with self.subTest(f"RGBA={value}"):
+                data = {"color": value}
+                serializer = SerializerWithColor(data=data)
+                self.assertTrue(serializer.is_valid())
 
     def test_invalid_serializer(self):
         data = {"color": self.invalid_hex_full_color1}
-        serializer = SerializerWithHexColor(data=data)
+        serializer = SerializerWithColor(data=data)
         self.assertFalse(serializer.is_valid())
         with self.assertRaises(DRFValidationError):
             serializer.is_valid(raise_exception=True)
 
         data = {"color": self.invalid_hex_full_color2}
-        serializer = SerializerWithHexColor(data=data)
+        serializer = SerializerWithColor(data=data)
         self.assertFalse(serializer.is_valid())
         with self.assertRaises(DRFValidationError):
             serializer.is_valid(raise_exception=True)
 
         data = {"color": self.invalid_hex_short_color1}
-        serializer = SerializerWithHexColor(data=data)
+        serializer = SerializerWithColor(data=data)
         self.assertFalse(serializer.is_valid())
         with self.assertRaises(DRFValidationError):
             serializer.is_valid(raise_exception=True)
 
         data = {"color": self.invalid_hex_short_color2}
-        serializer = SerializerWithHexColor(data=data)
+        serializer = SerializerWithColor(data=data)
         self.assertFalse(serializer.is_valid())
         with self.assertRaises(DRFValidationError):
             serializer.is_valid(raise_exception=True)
 
         data = {"color": self.invalid_hexa_full_color1}
-        serializer = SerializerWithHexColor(data=data)
+        serializer = SerializerWithColor(data=data)
         self.assertFalse(serializer.is_valid())
         with self.assertRaises(DRFValidationError):
             serializer.is_valid(raise_exception=True)
 
         data = {"color": self.invalid_hexa_full_color2}
-        serializer = SerializerWithHexColor(data=data)
+        serializer = SerializerWithColor(data=data)
         self.assertFalse(serializer.is_valid())
         with self.assertRaises(DRFValidationError):
             serializer.is_valid(raise_exception=True)
 
         data = {"color": self.invalid_hexa_short_color1}
-        serializer = SerializerWithHexColor(data=data)
+        serializer = SerializerWithColor(data=data)
         self.assertFalse(serializer.is_valid())
         with self.assertRaises(DRFValidationError):
             serializer.is_valid(raise_exception=True)
 
         data = {"color": self.invalid_hexa_short_color2}
-        serializer = SerializerWithHexColor(data=data)
+        serializer = SerializerWithColor(data=data)
         self.assertFalse(serializer.is_valid())
         with self.assertRaises(DRFValidationError):
             serializer.is_valid(raise_exception=True)
+
+        for value in self.invalid_rgb_colors:
+            with self.subTest(f"RGB={value}"):
+                data = {"color": value}
+                serializer = SerializerWithColor(data=data)
+                self.assertFalse(serializer.is_valid())
+                with self.assertRaises(DRFValidationError):
+                    serializer.is_valid(raise_exception=True)
+
+        for value in self.invalid_rgba_colors:
+            with self.subTest(f"RGBA={value}"):
+                data = {"color": value}
+                serializer = SerializerWithColor(data=data)
+                self.assertFalse(serializer.is_valid())
+                with self.assertRaises(DRFValidationError):
+                    serializer.is_valid(raise_exception=True)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -52,6 +52,7 @@ class ColorFieldTestCase(TestCase):
             "rgba(45,10, 99, 0.6)",
             "rgba(128, 128, 128, 0.3)",
             "rgba(128, 128, 128, 0.34)",
+            "rgba(128, 128, 128, 1.0)",
             "rgba(156,200,250,0)",
         ]
         self.invalid_rgba_colors = [

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -51,6 +51,7 @@ class ColorFieldTestCase(TestCase):
             "rgba(50, 30, 128, 0.5)",
             "rgba(45,10, 99, 0.6)",
             "rgba(128, 128, 128, 0.3)",
+            "rgba(128, 128, 128, 0.34)",
             "rgba(156,200,250,0)",
         ]
         self.invalid_rgba_colors = [
@@ -62,6 +63,7 @@ class ColorFieldTestCase(TestCase):
             "rgba(128,255,127,A)",
             "rgba(128, 255, 127, A)",
             "rgba(128, 255, 127, 1.5)",
+            "rgba(128, 255, 127, 0.6777777)",
             "rgba(128, 12, 35, 1, 1)",
             "rgba(128, 12, 35, 1, 1, 2)",
         ]

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -61,6 +61,7 @@ class ColorFieldTestCase(TestCase):
             "rgba(128,255,127)",
             "rgba(128,255,127,A)",
             "rgba(128, 255, 127, A)",
+            "rgba(128, 255, 127, 1.5)",
             "rgba(128, 12, 35, 1, 1)",
             "rgba(128, 12, 35, 1, 1, 2)",
         ]


### PR DESCRIPTION
---
name: Pull request
about: Submit a pull request for this project
assignees: fabiocaccamo

---

**Describe your changes**
Add support for RGB and RGBA formats

**Related issue**
https://github.com/fabiocaccamo/django-colorfield/pull/84

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [x] I have added tests for the proposed changes.
- [x] I have run the tests and there are not errors.
